### PR TITLE
fix: sync bun lock

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,11 +4,11 @@
     "": {
       "name": "{{projectSlug}}",
       "devDependencies": {
-        "typescript": "^5.0.0",
+        "typescript": "^5.9.3",
       },
     },
   },
   "packages": {
-    "typescript": ["typescript@5.8.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ=="],
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
   }
 }


### PR DESCRIPTION
## Summary
- update bun.lock via bun install so Bun-based builds (bun install --frozen-lockfile) match the npm TypeScript bump

## Testing
- bun install
- npm run build