### PR TITLE
chore: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,27 @@
 version: 2
-
 updates:
   - package-ecosystem: npm
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
     open-pull-requests-limit: 10
+    groups:
+      all-version-updates:
+        patterns:
+          - '*'
+      all-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'
   - package-ecosystem: github-actions
-    directory: "/"
+    directory: /
     schedule:
       interval: weekly
+    groups:
+      all-version-updates:
+        patterns:
+          - '*'
+      all-security-updates:
+        applies-to: security-updates
+        patterns:
+          - '*'


### PR DESCRIPTION
Group Dependabot version and security updates for each ecosystem.